### PR TITLE
Replace deprecated Pyplot "renderer.M" object

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.9.2 (TBD)
+--------------------------
+
+Bug fixes & improvements
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fixed an error related to a deprecated matplotlib.pyplot reference, see `Issue #35 <https://github.com/phausamann/rigid-body-motion/issues/35>`.
+
 0.9.1 (January 13th, 2022)
 --------------------------
 

--- a/rigid_body_motion/plotting.py
+++ b/rigid_body_motion/plotting.py
@@ -18,7 +18,7 @@ class Arrow3D(FancyArrowPatch):
     def draw(self, renderer):
         """ Draw to the given renderer. """
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        xs, ys, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         FancyArrowPatch.draw(self, renderer)
 


### PR DESCRIPTION
The object `rendered.M` has been removed from matplotlib.pyplot v3.4.
This PR allows compatibility with newer version of pyplot and resolves [Issue #35](https://github.com/phausamann/rigid-body-motion/issues/35).